### PR TITLE
Add mysql healthcheck to example docker-compose

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2.1'
 
 services:
   db:
@@ -8,6 +8,10 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: rootpassword
+    volumes:
+      - ./mysql/docker-healthcheck:/usr/local/bin/docker-healthcheck
+    healthcheck:
+      test: "docker-healthcheck"
     networks:
       apollonet:
         aliases:
@@ -24,6 +28,9 @@ services:
     volumes:
       - ./apollo.conf:/root/apollo.conf
       - ./nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      db:
+        condition: service_healthy
     networks:
       apollonet:
         aliases:

--- a/examples/mysql/docker-healthcheck
+++ b/examples/mysql/docker-healthcheck
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Project: docker-library/healthcheck (https://github.com/docker-library/healthcheck)
+# File source: https://github.com/docker-library/healthcheck/blob/master/mysql/docker-healthcheck
+
+set -eo pipefail
+
+if [ "$MYSQL_RANDOM_ROOT_PASSWORD" ] && [ -z "$MYSQL_USER" ] && [ -z "$MYSQL_PASSWORD" ]; then
+	# there's no way we can guess what the random MySQL password was
+	echo >&2 'healthcheck error: cannot determine random root password (and MYSQL_USER and MYSQL_PASSWORD were not set)'
+	exit 0
+fi
+
+host="$(hostname --ip-address || echo '127.0.0.1')"
+user="${MYSQL_USER:-root}"
+export MYSQL_PWD="${MYSQL_PASSWORD:-$MYSQL_ROOT_PASSWORD}"
+
+args=(
+	# force mysql to not use the local "mysqld.sock" (test "external" connectibility)
+	-h"$host"
+	-u"$user"
+	--silent
+)
+
+if select="$(echo 'SELECT 1' | mysql "${args[@]}")" && [ "$select" = '1' ]; then
+	exit 0
+fi
+
+exit 1


### PR DESCRIPTION
Add healthcheck to MySQL container and start apollo only after MySQL is ready.
Fixes #114 