### PR TITLE
Fix deployment commit label when canceling deployment

### DIFF
--- a/apollo-backend/src/main/java/io/logz/apollo/transformers/deployment/DeploymentLabelsTransformer.java
+++ b/apollo-backend/src/main/java/io/logz/apollo/transformers/deployment/DeploymentLabelsTransformer.java
@@ -8,6 +8,9 @@ import io.logz.apollo.transformers.LabelsNormalizer;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.logz.apollo.models.Deployment.DeploymentStatus.CANCELING;
+import static io.logz.apollo.models.Deployment.DeploymentStatus.PENDING_CANCELLATION;
+
 /**
  * Created by roiravhon on 1/31/17.
  */
@@ -21,12 +24,17 @@ public class DeploymentLabelsTransformer implements BaseDeploymentTransformer {
                                 io.logz.apollo.models.DeployableVersion apolloDeployableVersion,
                                 io.logz.apollo.models.Group group) {
 
+        String gitCommitSha = apolloDeployableVersion.getGitCommitSha();
+        if (apolloDeployment.getStatus().equals(PENDING_CANCELLATION) || apolloDeployment.getStatus().equals(CANCELING)) {
+            gitCommitSha = apolloDeployment.getSourceVersion();
+        }
+
         Map<String, String> desiredLabels = ImmutableMap.<String, String> builder()
                 .put("environment", LabelsNormalizer.normalize(apolloEnvironment.getName()))
                 .put("geo_region", LabelsNormalizer.normalize(apolloEnvironment.getGeoRegion()))
                 .put("service", LabelsNormalizer.normalize(apolloService.getName()))
                 .put("availability", LabelsNormalizer.normalize(apolloEnvironment.getAvailability()))
-                .put(ApolloToKubernetes.getApolloCommitShaKey(), LabelsNormalizer.normalize(apolloDeployableVersion.getGitCommitSha()))
+                .put(ApolloToKubernetes.getApolloCommitShaKey(), LabelsNormalizer.normalize(gitCommitSha))
                 .put(ApolloToKubernetes.getApolloDeploymentUniqueIdentifierKey(),
                         ApolloToKubernetes.getApolloDeploymentUniqueIdentifierValue(apolloEnvironment, apolloService, Optional.ofNullable(apolloDeployment.getGroupName())))
                 .build();


### PR DESCRIPTION
When canceling deployment the image name transformer checks the deployment status and in case the status is `PENDING_CANCELLATION` or `CANCELING` it uses the `sourceVersion` as the image tag.
We were missing this logic in the labels transformer which resulted in reverted version with the git_commit_sha of the new version of the service.
The issue is getting worse when deploying after the revert, at that point the source version of the new deployment will be the version that was reverted instead of the real one.

CC @roiravhon