### PR TITLE
Fix MySQL License

### DIFF
--- a/apollo-backend/pom.xml
+++ b/apollo-backend/pom.xml
@@ -102,8 +102,18 @@
         </dependency>
         <dependency>
             <groupId>org.rapidoid</groupId>
-            <artifactId>rapidoid-quick</artifactId>
+            <artifactId>rapidoid-web</artifactId>
             <version>5.3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+            <version>4.3.11.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-c3p0</artifactId>
+            <version>4.3.11.Final</version>
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>

--- a/apollo-backend/src/test/java/io/logz/apollo/helpers/ApolloMySQL.java
+++ b/apollo-backend/src/test/java/io/logz/apollo/helpers/ApolloMySQL.java
@@ -13,6 +13,17 @@ import java.sql.SQLException;
  */
 public class ApolloMySQL {
 
+    class ApolloMySQLContainer extends MySQLContainer{
+
+        public ApolloMySQLContainer(String mySqlDockerImage) {
+            super(mySqlDockerImage);
+        }
+
+        public String getDriverClassName() {
+            return "org.mariadb.jdbc.Driver";
+        }
+    }
+
     private static final Logger logger = LoggerFactory.getLogger(ApolloMySQL.class);
     private final MySQLContainer mysql;
 
@@ -20,7 +31,7 @@ public class ApolloMySQL {
 
         // Create mysql instance
         logger.info("Starting MySQL container");
-        mysql = new MySQLContainer("mysql:5.7.22");
+        mysql = new ApolloMySQLContainer("mysql:5.7.22");
         mysql.start();
     }
 


### PR DESCRIPTION
1. Reduced dependency from rapidoid-quick to rapidoid-web. 
2. Added ApolloMySQLContainer that supports mariadb driver over mysql.